### PR TITLE
file: unix: macos: Resize file chunks if needed

### DIFF
--- a/src/cio_file_unix.c
+++ b/src/cio_file_unix.c
@@ -112,35 +112,41 @@ int cio_file_native_map(struct cio_file *cf, size_t map_size)
 int cio_file_native_remap(struct cio_file *cf, size_t new_size)
 {
     int   result;
-    void *tmp = NULL;
+    void *tmp;
 
     result = 0;
 
-    if (new_size > cf->alloc_size) {
 /* OSX mman does not implement mremap or MREMAP_MAYMOVE. */
 #ifndef MREMAP_MAYMOVE
-        result = cio_file_native_unmap(cf);
-        if (result != 0) {
-            return CIO_ERROR;
-        }
+    /* OSX unmap/mmap pair should be succeeded for provided new_size
+     * to be grearter than pagesize case.
+     * If not, this sort of operation will cause memory corruptions.
+     * Just return early here. */
+    if (cio_getpagesize() > new_size) {
+        return CIO_OK;
+    }
 
-        tmp = mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, cf->fd, 0);
+    result = cio_file_native_unmap(cf);
 
+    if (result == -1) {
+        return result;
+    }
+
+    tmp = mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, cf->fd, 0);
 #else
-        (void) result;
+    (void) result;
 
-        tmp = mremap(cf->map, cf->alloc_size, new_size, MREMAP_MAYMOVE);
+    tmp = mremap(cf->map, cf->alloc_size, new_size, MREMAP_MAYMOVE);
 #endif
 
-        if (tmp == MAP_FAILED) {
-            cio_file_native_report_os_error();
+    if (tmp == MAP_FAILED) {
+        cio_file_native_report_os_error();
 
-            return CIO_ERROR;
-        }
-
-        cf->map = tmp;
-        cf->alloc_size = new_size;
+        return CIO_ERROR;
     }
+
+    cf->map = tmp;
+    cf->alloc_size = new_size;
 
     return CIO_OK;
 }

--- a/src/cio_file_unix.c
+++ b/src/cio_file_unix.c
@@ -119,10 +119,8 @@ int cio_file_native_remap(struct cio_file *cf, size_t new_size)
     if (new_size > cf->alloc_size) {
 /* OSX mman does not implement mremap or MREMAP_MAYMOVE. */
 #ifndef MREMAP_MAYMOVE
-        result = munmap(cf->map, cf->alloc_size);
+        result = cio_file_native_unmap(cf);
         if (result != 0) {
-            cio_file_native_report_os_error();
-
             return CIO_ERROR;
         }
 


### PR DESCRIPTION
Currently, resizing operation is always kicked and resized for mmap-ed files.
However, on new_size < cf->alloc_size case, it will cause invalid status of mmap-ed files on macOS.