### PR TITLE
cio_file: fix for SIGSEGV

### DIFF
--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -927,6 +927,9 @@ int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count)
     if (av_size < count) {
         pre_content = (CIO_FILE_HEADER_MIN + meta_len);
         new_size = cf->alloc_size + cf->realloc_size;
+        while (new_size < (pre_content + cf->data_size + count)) {
+            new_size += cf->realloc_size;
+        }
 
         new_size = ROUND_UP(new_size, ch->ctx->page_size);
         ret = cio_file_resize(cf, new_size);


### PR DESCRIPTION
When allocating larger buffers it is still necessary to set the new_size higher than the requested size so the loop needs to be brought back.

```
Thread 2 "flb-pipeline" hit Breakpoint 1, cio_file_write (ch=0x7ffff003c030, buf=0x7ffff5374010, 
    count=531440)
    at /home/pwhelan/Projects/work/fluent-bit.git/2.1.8/lib/chunkio/src/cio_file.c:927
927	   if (av_size < count) {
(gdb) print av_size
$5 = 4043
(gdb) print count
$6 = 531440
(gdb) next
928	       pre_content = (CIO_FILE_HEADER_MIN + meta_len);
(gdb) 
929	       new_size = cf->alloc_size + cf->realloc_size;
(gdb) 
931	       new_size = ROUND_UP(new_size, ch->ctx->page_size);
(gdb) print new_size
$7 = 528384
(gdb) next
932	       ret = cio_file_resize(cf, new_size);
(gdb) print new_size
$8 = 528384
(gdb) 
```
