### PR TITLE
Delete irrecoverable chunks on crc32 checksum error

### DIFF
--- a/src/cio_scan.c
+++ b/src/cio_scan.c
@@ -107,7 +107,8 @@ static int cio_scan_stream_files(struct cio_ctx *ctx, struct cio_stream *st,
         if (ctx->options.flags & CIO_DELETE_IRRECOVERABLE) {
             if (err == CIO_CORRUPTED) {
                 if (ctx->last_chunk_error == CIO_ERR_BAD_FILE_SIZE ||
-                    ctx->last_chunk_error == CIO_ERR_BAD_LAYOUT)
+                    ctx->last_chunk_error == CIO_ERR_BAD_LAYOUT ||
+                    ctx->last_chunk_error == CIO_ERR_BAD_CHECKSUM)
                 {
                     cio_log_error(ctx, "[cio scan] discarding irrecoverable chunk");
 


### PR DESCRIPTION
In Fluent Bit we see many corrupted chunks (resulting from previous OOM kills in Kubernetes) but they still remain on the disk indefinitely, although the `storage.delete_irrecoverable_chunks` parameter is set.
![Bildschirmfoto 2024-08-22 um 15 09 35](https://github.com/user-attachments/assets/bcc655de-22d7-4dd9-829a-eecc1bb76678)

It looks like the set `CIO_ERR_BAD_CHECKSUM` is currently not used as a case for deletion. 

This PR should correct this behavior. 

cc @edsiper 