### PR TITLE
os: dirent: Avoid to use PathIsDirectoryA and SHCreateDirectoryEx for Nano win server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 48
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019]
+        os: [windows-2025, windows-2022]
     steps:
       - uses: actions/checkout@v2
       - name: Build on ${{ matrix.os }} with vs-2019

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,12 +18,17 @@ jobs:
         os: [windows-2025, windows-2022]
     steps:
       - uses: actions/checkout@v2
-      - name: Build on ${{ matrix.os }} with vs-2019
+      - name: Set up with Developer Command Prompt for Microsoft Visual C++
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+      - name: Build on ${{ matrix.os }} with MSVC
         run: |
-          .\scripts\win_build.bat
+          cmake -G "NMake Makefiles" -DCIO_TESTS=On .
+          cmake --build .
       - name: Run unit tests.
         run: |
-          ctest --rerun-failed --output-on-failure -C Debug --test-dir .
+          ctest . --rerun-failed --output-on-failure --test-dir .
   build-unix:
     name: Build sources on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     )
   set(libs
     ${libs}
-    Shell32.lib
-    Shlwapi.lib)
+    Shell32.lib)
 else()
   set(src
     ${src}

--- a/src/win32/dirent.c
+++ b/src/win32/dirent.c
@@ -75,11 +75,30 @@ static char *create_pattern(const char *path)
     return buf;
 }
 
+/**
+ * @brief Checks if a given path string refers to an existing directory.
+ * @param pszPath The null-terminated string that contains the path.
+ * @return Returns TRUE if the path is a directory, otherwise FALSE.
+ */
+BOOL path_is_directory(LPCSTR pszPath) {
+    DWORD dwAttrib = GetFileAttributesA(pszPath);
+
+    if (dwAttrib == INVALID_FILE_ATTRIBUTES) {
+        return FALSE;
+    }
+
+    if (dwAttrib & FILE_ATTRIBUTE_DIRECTORY) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 struct CIO_WIN32_DIR *cio_win32_opendir(const char *path)
 {
     struct CIO_WIN32_DIR *d;
 
-    if (!PathIsDirectoryA(path)) {
+    if (!path_is_directory(path)) {
         return NULL;
     }
 

--- a/src/win32/dirent.c
+++ b/src/win32/dirent.c
@@ -23,7 +23,6 @@
  */
 
 #include <Windows.h>
-#include <shlwapi.h>
 
 #include "dirent.h"
 


### PR DESCRIPTION
For Windows Nano Server supporting, we need to replace non existing APIs in Windows Nano Server.
At first, we need to remove the dependencies for PathIsDirectoryA and SHCreateDirectoryEx APIs.
In this PR, avoiding to use PathIsDirectoryA and SHCreateDirectoryEx.
This API is targeted for ordinary Windows platforms.
The full list of supported APIs in Windows Nano Server are:
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt588480(v=vs.85)