### PR TITLE
build: fix MinGW-w64 cross-compilation for Windows

### DIFF
--- a/include/chunkio/chunkio_compat.h
+++ b/include/chunkio/chunkio_compat.h
@@ -42,8 +42,10 @@
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 
+#ifndef __MINGW32__
 typedef SSIZE_T ssize_t;
 typedef unsigned mode_t;
+#endif
 
 static inline char* dirname(const char *path)
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     )
   set(libs
     ${libs}
-    Shell32.lib)
+    shell32)
 else()
   set(src
     ${src}

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -28,7 +28,7 @@
 #include <chunkio/chunkio_compat.h>
 
 #ifdef _WIN32
-#include <Shlobj.h>
+#include <shlobj.h>
 #endif
 
 /* Check if a path is a directory */

--- a/src/cio_utils.c
+++ b/src/cio_utils.c
@@ -25,7 +25,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <fts.h>
 #endif
 
@@ -34,7 +34,7 @@
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_log.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 /*
  * Taken from StackOverflow:
  *

--- a/src/win32/dirent.c
+++ b/src/win32/dirent.c
@@ -22,7 +22,7 @@
  * Win32's FIndFirstFile/FindNextFile API.
  */
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "dirent.h"
 


### PR DESCRIPTION
This lets chunkio build for a Windows target with the MinGW-w64 UCRT toolchain (GCC), in addition to MSVC. The changes are no-ops for MSVC builds:

- Guard the `ssize_t` and `mode_t` typedefs in `chunkio_compat.h` with `!__MINGW32__` — MinGW-w64 already provides both, and redefining them fails to compile.
- Widen the `fts.h` gate in `cio_utils.c` from `_MSC_VER` to `!_WIN32`: `fts.h` is absent on any Windows toolchain, not just MSVC.
- Lowercase the capitalized Windows header includes (`<Shlobj.h>` → `<shlobj.h>`, `<Windows.h>` → `<windows.h>`) so they resolve when cross-compiling from a case-sensitive filesystem. MSVC on a case-insensitive filesystem is unaffected.
- Link `shell32` by its lowercase name in `src/CMakeLists.txt` so GNU ld resolves the import library; CMake still appends `.lib` for MSVC.

### Testing

Verified by cross-compiling Fluent Bit (which bundles chunkio) for Windows from Linux with the Fedora MinGW-w64 UCRT toolchain — chunkio compiles and links into a working `fluent-bit.exe` (PE32+ x86-64). The MSVC build path is unchanged: the typedef guards keep MSVC on its existing branch, the header-case changes are inert on a case-insensitive filesystem, and the `fts.h`/`shell32` changes resolve identically under MSVC.